### PR TITLE
Custom config and kernel name

### DIFF
--- a/src/cocotb_kernel/__main__.py
+++ b/src/cocotb_kernel/__main__.py
@@ -9,11 +9,11 @@ import cocotb_kernel.module as test_module
 
 
 # TODO: Add support for custom configuration file name
-def find_config() -> Path | None:
+def find_config(config_name:(str | None) = None) -> Path | None:
     cwd = Path().resolve()
     dirs = [cwd, *cwd.parents]
     for dir in dirs:
-        config_file = dir / "cocotb.toml"
+        config_file = dir / f"{config_name}.toml"
         if config_file.exists():
             return config_file
     return None
@@ -32,12 +32,12 @@ def main() -> None:
     # Parse arguments
     parser = argparse.ArgumentParser()
     parser.add_argument("--connection-file", type=str)
-    parser.add_argument("--config-name", type=str)  # TODO: Add support for custom config name
+    parser.add_argument("--config-name", type=str)
     args = parser.parse_args()
 
     # Load config
-    if (config := find_config()) is None:
-        raise RuntimeError("Cannot start cocotb kernel: couldn't find cocotb.toml")
+    if (config := find_config(config_name=args.config_name)) is None:
+        raise RuntimeError(f"Cannot start cocotb kernel: couldn't find {args.config_name}.toml")
     with open(config, "rb") as f:
         options = tomllib.load(f)
 

--- a/src/cocotb_kernel/__main__.py
+++ b/src/cocotb_kernel/__main__.py
@@ -8,7 +8,6 @@ from cocotb.runner import get_runner  # type: ignore
 import cocotb_kernel.module as test_module
 
 
-# TODO: Add support for custom configuration file name
 def find_config(config_name:(str | None) = None) -> Path | None:
     cwd = Path().resolve()
     dirs = [cwd, *cwd.parents]

--- a/src/cocotb_kernel/install.py
+++ b/src/cocotb_kernel/install.py
@@ -6,24 +6,29 @@ from pathlib import Path
 
 from jupyter_client.kernelspec import install_kernel_spec
 
-kernel_json = {
-    "argv": [sys.executable, "-m", "cocotb_kernel", "--connection-file", "{connection_file}"],
-    "display_name": "cocotb",
-    "language": "python",
-    "metadata": {"debugger": True},
-}
 
 
-# TODO: Add support for custom config name
 def install_cocotb_kernelspec(
-    user: bool = True, prefix: (str | None) = None, config_name: (str | None) = None
+    user: bool = True,
+    prefix: (str | None) = None,
+    config_name: (str | None) = None,
+    kernel_name: (str | None) = None
 ) -> str:
+    kernel_json = {
+        "argv": [sys.executable,
+                 "-m", "cocotb_kernel",
+                 "--connection-file", "{connection_file}",
+                 "--config-name", config_name],
+        "display_name": kernel_name,
+        "language": "python",
+        "metadata": {"debugger": True},
+    }
     with tempfile.TemporaryDirectory() as td:
         with open(Path(td, "kernel.json"), "w") as f:
             json.dump(kernel_json, f, sort_keys=True)
 
         print("Installing cocotb kernelspec")
-        return install_kernel_spec(td, "cocotb", user=user, prefix=prefix)
+        return install_kernel_spec(td, kernel_name=kernel_name, user=user, prefix=prefix)
 
 
 def main() -> None:
@@ -46,6 +51,10 @@ def main() -> None:
         "--config-name", help="Name of the toml file (default is cocotb)", default="cocotb"
     )
 
+    parser.add_argument(
+        "--kernel_name", help="Name of the kernel (default is cocotb)", default="cocotb"
+    )
+
     args = parser.parse_args()
 
     user = False
@@ -57,7 +66,10 @@ def main() -> None:
     elif args.user:
         user = True
 
-    destination = install_cocotb_kernelspec(user=user, prefix=prefix, config_name=args.config_name)
+    destination = install_cocotb_kernelspec(user=user,
+                                            prefix=prefix,
+                                            config_name=args.config_name,
+                                            kernel_name=args.kernel_name)
     print(f"Installed cocotb kernel to {destination}")
 
 


### PR DESCRIPTION
I just found this module and after playing around with it I realized that:
- the custom config was not yet working, so I added the missing pieces and
- If you want to have a few different configs without rebuilding the kernel each time adding custom kernel names is quite useful, so I added that too